### PR TITLE
Add user id into session and reuse it in backend

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,6 +1,7 @@
 import { Db, MongoClient, MongoClientOptions, ObjectId } from 'mongodb';
 import { NextApiRequest } from 'next';
 import { Session } from 'next-auth';
+import { getSession } from "next-auth/client";
 
 const { MONGODB_URI, MONGODB_DB } = process.env;
 
@@ -116,26 +117,17 @@ export const IncidentDao = {
   },
 };
 
-export const SessionDao = {
-  async getSessionFromReq(req: NextApiRequest) {
-    const sessionToken = req.cookies['next-auth.session-token'];
+export const UserDao = {
+  async getUserIdFromSession(req: NextApiRequest) {
+    const session = await getSession({ req });
 
-    if (!sessionToken) {
-      throw new Error('No session found in cookies');
+    if (!session || !session.userId) {
+      throw new Error('No Session!');
     }
 
-    const { db } = await connectToDatabase();
-    const session = await db
-      .collection<Session>('sessions')
-      .findOne({ sessionToken });
-
-    if (!session) {
-      throw new Error('No session found');
-    }
-
-    return session;
-  },
-};
+    return String(session.userId);
+  }
+}
 
 export function safeStringify(obj: unknown) {
   return JSON.parse(JSON.stringify(obj));

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,5 +1,6 @@
 import NextAuth from 'next-auth';
 import Providers from 'next-auth/providers';
+import { ObjectId } from 'mongodb';
 
 export default NextAuth({
   providers: [
@@ -10,4 +11,14 @@ export default NextAuth({
   ],
 
   database: process.env.MONGODB_URI,
+
+  callbacks: {
+    session(session, user) {
+      if ("id" in user) {
+        session.userId = new ObjectId(String(user.id));
+      }
+
+      return session;
+    },
+  },
 });

--- a/pages/api/user.ts
+++ b/pages/api/user.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { connectToDatabase, Incident, IncidentDao, SessionDao } from 'lib/db';
+import { connectToDatabase, Incident, IncidentDao, UserDao } from 'lib/db';
 import { User } from 'next-auth';
 import { ObjectId } from 'mongodb';
 
@@ -12,21 +12,19 @@ export default async function UserAPI(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void | UserView> {
-  let session;
+  let userId;
 
   try {
-    session = await SessionDao.getSessionFromReq(req);
+    userId = await UserDao.getUserIdFromSession(req);
   } catch (error) {
     return res.status(401).end();
   }
-
-  const { userId: sessionUserId } = session;
 
   const { db } = await connectToDatabase();
 
   const user = await db
     .collection<User>('users')
-    .findOne({ _id: new ObjectId(sessionUserId) });
+    .findOne({ _id: new ObjectId(userId) });
 
   if (!user) {
     return res.status(403).end();


### PR DESCRIPTION
Hi Harry,

I watched your video today about session and the way you solved it by getting access to cookie and then retrieving session (and user) from the database. It looks very tricky for me, and I am not sure if it is a correct way to get "internal next-auth cookies".

I think there might be a better way to get the user id from session, but first you need to add it to the session, see docs:
https://next-auth.js.org/configuration/callbacks#session-callback

and then it's easy to get it back in the backend. Tbh, I would expect to be done automatically in next-auth as we persist users in the database. I do not have more time today to investigate it more. Please note that in session we already have field `userId` with expected `ObjectId` type. That's why I would expect the id to be there when user is stored in the db.

Hope it helps :) Thanks!